### PR TITLE
Fix Failing Navigation because of missing Swipe Gesture Delegate on iOS

### DIFF
--- a/MPowerKit.Navigation/PlatformSpecific/MauiNavKitNavigtaionRenderer.MaciOS.cs
+++ b/MPowerKit.Navigation/PlatformSpecific/MauiNavKitNavigtaionRenderer.MaciOS.cs
@@ -8,11 +8,11 @@ namespace MPowerKit.Navigation.PlatfromSpecific;
 
 public class MPowerKitNavigtaionRenderer : NavigationRenderer
 {
-    public override void ViewDidLoad()
+    public override void ViewWillAppear(bool animated)
     {
-        base.ViewDidLoad();
-
         InteractivePopGestureRecognizer.Delegate = new SwipeBackDelegate(this);
+        
+        base.ViewWillAppear(animated);
     }
 
     public override void ViewWillDisappear(bool animated)


### PR DESCRIPTION
The Delegate was added in `MPowerKitNavigtaionRenderer` in `ViewDidLoad` and is removed in `ViewWillDisappear`.

If the View stays in Memory `ViewDidLoad` is only called once. So when Navigating to the same View again, the `SwipeBackDelegate` will not be set and SwipeGestures will not be handled.

This fix adds the Delegate in `ViewWillAppear` so it will be added every time the view is opened.